### PR TITLE
FIX: Setting the cable connection to enable communication with VM

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -18,6 +18,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provider "virtualbox" do |v|
     v.memory = 4000
     v.name = "oracle12c-vagrant"
+    v.customize ["modifyvm", :id, "--cableconnected1", "on"]
   end
 
   # Oracle port forwarding


### PR DESCRIPTION
With Vagrant 1.8.6. and 1.8.7 it was not possible to establish a SSH connection to the VM